### PR TITLE
create Collection Feedback and unique indexes for Collections

### DIFF
--- a/data_generators/data_options.py
+++ b/data_generators/data_options.py
@@ -305,6 +305,11 @@ subjects = (
     "General Programming",
 )
 
+feedbacks = (
+    "Not Recommended, Poor", "Conflicted, Fair", "Recommended, Good",
+    "Highly Recommended, Very Good", "Best, Excellent "
+)
+
 
 def random_first_name(percent_male: int = 50):
     if randint(1, 100) > percent_male:

--- a/data_generators/user_generators.py
+++ b/data_generators/user_generators.py
@@ -25,7 +25,9 @@ class Mentor:
 
 
 class MenteeFeedback:
-
+    """Create feedback record from mentee (randomly selected from Mentees Collection) to
+    mentor (randomly selected from Mentors Collection), which is stored in Feedbacks Collection.
+    1 mentee can give multiple feedbacks to 1 mentor."""
     def __init__(self, mentee_ids, mentor_ids):
         self.mentee_id = choice(mentee_ids)
         self.mentor_id = choice(mentor_ids)

--- a/data_generators/user_generators.py
+++ b/data_generators/user_generators.py
@@ -24,11 +24,31 @@ class Mentor:
         self.skill_level = choice(skill_levels)
 
 
+class MenteeFeedback:
+
+    def __init__(self, mentee_ids, mentor_ids):
+        self.mentee_id = choice(mentee_ids)
+        self.mentor_id = choice(mentor_ids)
+        self.ticket_id = randint(1000000, 9000000)
+        self.feedback = choice(feedbacks)
+
+
 if __name__ == '__main__':
     db = MongoDB("UnderdogDevs")
 
     db.reset_collection("Mentees")
+    db._connect("Mentees").create_index("user_id", unique=True)
     db.create_many("Mentees", (vars(Mentee()) for _ in range(100)))
 
     db.reset_collection("Mentors")
+    db._connect("Mentors").create_index("user_id", unique=True)
     db.create_many("Mentors", (vars(Mentor()) for _ in range(20)))
+
+    db.reset_collection("Feedbacks")
+    mentees = db.read("Mentees")
+    mentors = db.read("Mentors")
+    db._connect("Feedbacks").create_index("ticket_id", unique=True)
+    feedbacks = [vars(MenteeFeedback([m['user_id'] for m in mentees],
+                                     [m['user_id'] for m in mentors]))
+                 for _ in range(200)]
+    db.create_many("Feedbacks", feedbacks)


### PR DESCRIPTION
## Description

• Data scientist needs mock data feedback from mentees to mentors to better predict the right mentors for mentees
• 5 categorical mock feedbacks are added in data_options.py: Poor, Fair, Good, Very Good, Excellent
• A new Collection Feedbacks is created in MongoDB Database UnderdogDevs 
• Unique indexes for Collections Mentees (user_id), Mentors (user_id), and Feedbacks (ticket_id) are set, to prevent inserting duplicate mock users or ticket_ids generated from user_generators.py (not from API) to MongoDB. This issue does not exist in API as API pops an error message when creating a duplicate user.

https://www.loom.com/share/93455ac48def467f930b346948174617

## Type of change

- [x] New feature

## Checklist:

- [x] My code follows PEP8 style guide
- [x] I have removed unnecessary print statements from my code
- [x] I have made corresponding changes to the documentation if necessary
- [x] My changes generate no errors
- [x] No commented-out code
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
