### PR TITLE
Removed extra call in api.py in `collections` endpoint

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -33,7 +33,7 @@ async def version():
 @API.get("/collections")
 async def collections():
     """Return collection names and a count of their child nodes."""
-    return {"result": API.db.get_database_info()()}
+    return {"result": API.db.get_database_info()}
 
 
 @API.post("/{collection}/create")


### PR DESCRIPTION
## Description

There was a breaking bug in the collections endpoint. This fix removed an extra `()` call that snuck inside the endpoint. It works now normally.

Fixes # [Trello](https://trello.com/c/hXYaSogm)
Contributors: @OlatomiAdigun @Annapurnaj91 @sirivennelavempati 

## Type of change

- [X] Bug fix

## Checklist:

- [x] My code follows PEP8 style guide
- [x] I have removed unnecessary print statements from my code
- [x] I have made corresponding changes to the documentation if necessary
- [x] My changes generate no errors
- [x] No commented-out code
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
