### PR TITLE
Added .vscode/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ env.bak/
 venv.bak/
 *.yml
 .idea/
+.vscode/
 
 #python generated files 
 **/*.py[cod]


### PR DESCRIPTION
## Description

We were previously instructed to have .vscode added to the .gitignore in our personal repos. So I have added .vscode to the .gitignore file. If including the .vscode folder in the repo is intentional, please let me know. Here is a quick Loom video explaining the change: https://www.loom.com/share/db61398f61fb4fce9200838badadff37

## Type of change

- [x] Bug fix

## Checklist:

- [x] My code follows PEP8 style guide
- [x] I have removed unnecessary print statements from my code
- [x] I have made corresponding changes to the documentation if necessary
- [x] My changes generate no errors
- [x] No commented-out code
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
