### PR TITLE
Feature/sentiment numeric

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -7,7 +7,7 @@ from fastapi.responses import JSONResponse
 from app.data import MongoDB
 from app.utilities import financial_aid_gen
 from app.model import MatcherSortSearch, MatcherSortSearchResource
-from app.vader_sentiment import vader_score
+from app.vader_sentiment import vader_score, vader_numeric
 
 API = FastAPI(
     title='Underdog Devs DS API',
@@ -255,3 +255,16 @@ async def sentiment(text: str):
         positive/negative/neutral prediction based on sentiment analysis
     """
     return {"result": vader_score(text)}
+
+@API.post("/sentiment_numeric")
+async def sentiment_numeric(text: str) -> float:
+    """ Returns .
+
+    Args:
+        text (str): the text to be analyzed
+
+    Returns:
+        float (ranging from -1 to + 1) representing the overall sentiment of
+        the words within the text string.
+    """
+    return vader_numeric(text)

--- a/app/api.py
+++ b/app/api.py
@@ -265,6 +265,7 @@ async def sentiment_numeric(text: str) -> float:
 
     Returns:
         float (ranging from -1 to + 1) representing the overall sentiment of
-        the words within the text string.
+        the words within the text string. Allows more granular analysis of
+        sentiment.
     """
     return vader_numeric(text)

--- a/app/vader_sentiment.py
+++ b/app/vader_sentiment.py
@@ -15,5 +15,17 @@ def vader_score(text: str) -> str:
         return "Neutral"
 
 
+def vader_numeric(text: str) -> float:
+    """
+    Return numeric 'compound' score of text using vader analysis.
+    :param text: Input text (as string)
+    :return: float representing the Vader sentiment analysis' "Compound" score,
+    representing the overall sentiment of the words in the text string. Note
+    that the compound score values range from -1 (100% negative) to +1 (100%
+    positive).
+    """
+    return vader.polarity_scores(text)["compound"]
+
+
 if __name__ == '__main__':
     print(vader_score("good but not great"))

--- a/app/vader_sentiment.py
+++ b/app/vader_sentiment.py
@@ -20,7 +20,7 @@ def vader_numeric(text: str) -> float:
     Return numeric 'compound' score of text using vader analysis.
     :param text: Input text (as string)
     :return: float representing the Vader sentiment analysis' "Compound" score,
-    representing the overall sentiment of the words in the text string. Note
+    representing overall sentiment of the words in the text string. Note
     that the compound score values range from -1 (100% negative) to +1 (100%
     positive).
     """


### PR DESCRIPTION
## Description

This PR adds a 'sentiment_numeric' endpoint that expands upon the existing 'sentiment' endpoint. The existing endpoint returns "human-readable" sentiment scores of "Positive", "Negative", and "Neutral", which are great for summarizing and high level classification of sentiments. By adding a sentiment analyzer that returns numeric sentiment values (within ranges of -1 to +1), we enable more granular analysis of sentiment, opening the door for evaluating things such as trend analysis, forecasting, and more nuanced investigations into sentiment.

Authors:
@Zack-Quintana 
@BrandonSmith710 
@hollberg  

Fixes # (issue)
https://trello.com/c/h5AS5v84/285-as-a-data-science-developer-i-want-the-option-to-classify-texts-sentiment-in-either-human-terms-ie-positive-or-negative-or-with

## Type of change

- [x] New feature

## Checklist:

- [x] My code follows PEP8 style guide
- [x] I have removed unnecessary print statements from my code
- [x] I have made corresponding changes to the documentation if necessary
- [x] My changes generate no errors
- [x] No commented-out code
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes

Loom Video:
https://www.loom.com/share/bbac425c588040db8a62734a6336c13d