### PR TITLE
New Feature to add option to have a numerical value return from sentiment analysis. 

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -245,13 +245,22 @@ async def financial_aid(profile_id: str):
 
 
 @API.post("/sentiment")
-async def sentiment(text: str):
+async def sentiment(text: str, numerical: bool):
     """ Returns positive, negative or neutral sentiment of the supplied text.
 
     Args:
         text (str): the text to be analyzed
+        numerical(bool): if return value is a vader numeric value.(default = False)
+
 
     Returns:
         positive/negative/neutral prediction based on sentiment analysis
+        IF numerical == True:
+            returns a numeric value from vader sentiment
+
     """
-    return {"result": vader_score(text)}
+    if not numerical:
+        return {"result": vader_score(text, False)}
+    else:
+        return {"result": vader_score(text, True)}
+

--- a/app/vader_sentiment.py
+++ b/app/vader_sentiment.py
@@ -4,9 +4,11 @@ from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
 vader = SentimentIntensityAnalyzer()
 
 
-def vader_score(text: str) -> str:
+def vader_score(text: str, numerical: bool):
     """Return compound scores of text in list using vader analysis."""
     score = vader.polarity_scores(text)["compound"]
+    if numerical:
+        return score
     if score > 0.3:
         return "Positive"
     elif score < -0.3:
@@ -16,4 +18,13 @@ def vader_score(text: str) -> str:
 
 
 if __name__ == '__main__':
-    print(vader_score("good but not great"))
+    print(vader_score("good but not great", False))
+    """
+    This is to test the expected result requested in api.py
+
+    """
+    # Numeric
+    print({"Result": vader_score("Astring is so cool wow hot damn", True)})
+    # String text.
+    print({"Result": vader_score("Astring is so cool wow hot damn", False)})
+


### PR DESCRIPTION
same branch as Feature/numeric_sentiment_analysis

## Description

Added changes to allow for API endpoint to return a numerical value or not for sentiment function call. 

Feature addition [video](https://www.loom.com/share/ee5a4d671f8d4a36ae1128bb74f999db)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix
- [x] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows PEP8 style guide
- [x] I have removed unnecessary print statements from my code
- [x] I have made corresponding changes to the documentation if necessary
- [x] My changes generate no errors
- [x] No commented-out code
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
