### PR TITLE
Remove Numeric output from Sentiment endpoint

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -11,7 +11,7 @@ from app.vader_sentiment import vader_score
 
 API = FastAPI(
     title='Underdog Devs DS API',
-    version="0.44.4",
+    version="0.45.1",
     docs_url='/',
 )
 API.db = MongoDB("UnderdogDevs")

--- a/app/api.py
+++ b/app/api.py
@@ -245,22 +245,12 @@ async def financial_aid(profile_id: str):
 
 
 @API.post("/sentiment")
-async def sentiment(text: str, numerical: bool):
+async def sentiment(text: str):
     """ Returns positive, negative or neutral sentiment of the supplied text.
-
     Args:
         text (str): the text to be analyzed
-        numerical(bool): if return value is a vader numeric value.(default = False)
-
-
     Returns:
         positive/negative/neutral prediction based on sentiment analysis
-        IF numerical == True:
-            returns a numeric value from vader sentiment
-
     """
-    if not numerical:
-        return {"result": vader_score(text, False)}
-    else:
-        return {"result": vader_score(text, True)}
+    return {"result": vader_score(text)}
 

--- a/app/vader_sentiment.py
+++ b/app/vader_sentiment.py
@@ -4,11 +4,9 @@ from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
 vader = SentimentIntensityAnalyzer()
 
 
-def vader_score(text: str, numerical: bool):
-    """Return compound scores of text in list using vader analysis."""
+def vader_score(text: str):
+    """Return an intuitive string (Positive, Negative or Neutral) base on the compound score of text from vader analysis."""
     score = vader.polarity_scores(text)["compound"]
-    if numerical:
-        return score
     if score > 0.3:
         return "Positive"
     elif score < -0.3:
@@ -18,13 +16,13 @@ def vader_score(text: str, numerical: bool):
 
 
 if __name__ == '__main__':
-    print(vader_score("good but not great", False))
+    print(vader_score("good but not great"))
     """
     This is to test the expected result requested in api.py
 
     """
     # Numeric
-    print({"Result": vader_score("Astring is so cool wow hot damn", True)})
+    print({"Result": vader_score("Astring is so cool wow hot damn")})
     # String text.
-    print({"Result": vader_score("Astring is so cool wow hot damn", False)})
+    print({"Result": vader_score("Astring is so cool wow hot damn")})
 


### PR DESCRIPTION
## Description
https://www.loom.com/share/243829d1f850495080bf0cb146562e0d

Eliminate the posibility for numerical output from the /sentiment end point in the API, making modifications on vader_sentiment and api scripts.

## Type of change

- [x] Bug fix

## Checklist:

- [x] My code follows PEP8 style guide
- [x] I have made corresponding changes to the documentation if necessary
- [x] My changes generate no errors
- [x] No commented-out code
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
