### PR TITLE
Reworked Tech Stack and Removed Exp Variables

### DIFF
--- a/app/schema.py
+++ b/app/schema.py
@@ -3,17 +3,6 @@ from datetime import datetime
 from pydantic import BaseModel, constr
 
 
-class Variants:
-    exp_levels = Literal[
-        "Beginner", "Intermediate", "Advanced"
-    ]
-
-    tech_stacks = Literal[
-        "Career Development", "Frontend", "Backend",
-        "Design UI/UX", "iOS", "Android", "Data Science"
-    ]
-
-
 class Mentor(BaseModel):
     profile_id: constr(max_length=255)
     first_name: constr(max_length=255)
@@ -25,8 +14,6 @@ class Mentor(BaseModel):
     city: constr(max_length=255)
     current_company: constr(max_length=255)
     current_position: constr(max_length=255)
-    tech_stack: List[Variants.tech_stacks]
-    preferred_mentee_exp_level: Variants.exp_levels
     able_to_commit: bool
     mentor_contribution: List[constr(max_length=255)]
     how_heard_about_us: constr(max_length=255)
@@ -44,8 +31,6 @@ class MentorUpdate(BaseModel):
     city: Optional[constr(max_length=255)]
     current_company: Optional[constr(max_length=255)]
     current_position: Optional[constr(max_length=255)]
-    tech_stack: Optional[List[Variants.tech_stacks]]
-    preferred_mentee_exp_level: Optional[Variants.exp_levels]
     able_to_commit: Optional[bool]
     mentor_contribution: Optional[List[constr(max_length=255)]]
     how_heard_about_us: Optional[constr(max_length=255)]
@@ -65,8 +50,6 @@ class Mentee(BaseModel):
     underrepresented_group: bool
     low_income: bool
     list_convictions: List[constr(max_length=255)]
-    tech_stack: List[Variants.tech_stacks]
-    experience_level: Variants.exp_levels
     looking_for: List[constr(max_length=255)]
     anything_else: Optional[constr(max_length=2500)]
 
@@ -84,8 +67,6 @@ class MenteeUpdate(BaseModel):
     underrepresented_group: Optional[bool]
     low_income: Optional[bool]
     list_convictions: Optional[List[constr(max_length=255)]]
-    tech_stack: Optional[List[Variants.tech_stacks]]
-    experience_level: Optional[Variants.exp_levels]
     looking_for: Optional[List[constr(max_length=255)]]
     anything_else: Optional[constr(max_length=2500)]
 

--- a/app/schema.py
+++ b/app/schema.py
@@ -2,7 +2,6 @@ from typing import List, Literal, Optional
 from datetime import datetime
 from pydantic import BaseModel, constr
 
-
 class Mentor(BaseModel):
     profile_id: constr(max_length=255)
     first_name: constr(max_length=255)
@@ -14,6 +13,7 @@ class Mentor(BaseModel):
     city: constr(max_length=255)
     current_company: constr(max_length=255)
     current_position: constr(max_length=255)
+    tech_stack: constr(max_length=255)
     able_to_commit: bool
     mentor_contribution: List[constr(max_length=255)]
     how_heard_about_us: constr(max_length=255)
@@ -31,6 +31,7 @@ class MentorUpdate(BaseModel):
     city: Optional[constr(max_length=255)]
     current_company: Optional[constr(max_length=255)]
     current_position: Optional[constr(max_length=255)]
+    tech_stack: constr(max_length=255)
     able_to_commit: Optional[bool]
     mentor_contribution: Optional[List[constr(max_length=255)]]
     how_heard_about_us: Optional[constr(max_length=255)]
@@ -50,6 +51,7 @@ class Mentee(BaseModel):
     underrepresented_group: bool
     low_income: bool
     list_convictions: List[constr(max_length=255)]
+    tech_stack: constr(max_length=255)
     looking_for: List[constr(max_length=255)]
     anything_else: Optional[constr(max_length=2500)]
 
@@ -67,6 +69,7 @@ class MenteeUpdate(BaseModel):
     underrepresented_group: Optional[bool]
     low_income: Optional[bool]
     list_convictions: Optional[List[constr(max_length=255)]]
+    tech_stack: constr(max_length=255)
     looking_for: Optional[List[constr(max_length=255)]]
     anything_else: Optional[constr(max_length=2500)]
 


### PR DESCRIPTION
## Description

This was a relatively simple change as it was warranted by Jason. So instead of having the tech_stack be limited to specific areas such as Frontend, Backend, etc, it was opened up to accept any string input as to allow more freedom. That and I had also removed the experience level of both mentor and mentee as per request.

## Type of change
- [X] This change requires a documentation update

## Checklist:

- [X]  My code follows PEP8 style guide
- [X]  I have removed unnecessary print statements from my code
- [X]  I have made corresponding changes to the documentation if necessary
- [X]  My changes generate no errors
- [X] No commented-out code
- [X]  Size of pull request kept to a minimum
- [X]  Pull request description clearly describes changes made & motivations for said changes

My Loom Video: https://www.loom.com/share/8f5484cb18424bcfbe31d2746f00a14c