### PR TITLE
Bug/config schemas+refactor update endpoints

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -65,39 +65,35 @@ async def computer_assignment_rating_visualizer():
 
 
 @API.post("/update/mentors")
-async def update_mentors(query: Dict, update_data: Dict):
+async def update_mentors(query: Dict, update_data: MentorUpdate):
     """Updates Mentor documents that statisfy the query with update_data.
-
     Queries from Mentor Collection with filters given (query).
     Validate changes in update_data using MentorUpdate class (Pydantic schema)
     and updates the corresponding fields, by overwriting or adding data.
-
     Args:
         query (dict): Key value pairs to filter for
         update_data (dict): Key value pairs to update
     Returns:
         Updated fields or schema discrepancy error as dictionary
     """
-    MentorUpdate(**update_data)
-    return {"result": API.db.update("Mentors", query, update_data)}
+    data = update_data.dict(exclude_none=True)
+    return {"result": API.db.update("Mentors", query, data)}
 
 
 @API.post("/update/mentees")
-async def update_mentees(query: Dict, update_data: Dict):
+async def update_mentees(query: Dict, update_data: MenteeUpdate):
     """Updates Mentee documents that statisfy the query with update_data.
-
     Queries from Mentee Collection with filters given (query).
     Validate changes in update_data using MenteeUpdate class (Pydantic schema)
     and updates the corresponding fields, by overwriting or adding data.
-
     Args:
         query (dict): Key value pairs to filter for
         update_data (dict): Key value pairs to update
     Returns:
         Updated fields or schema discrepancy error as dictionary
     """
-    MenteeUpdate(**update_data)
-    return {"result": API.db.update("Mentees", query, update_data)}
+    data = update_data.dict(exclude_none=True)
+    return {"result": API.db.update("Mentees", query, data)}
 
 
 @API.post("/{collection}/create")

--- a/app/schema.py
+++ b/app/schema.py
@@ -1,6 +1,7 @@
 from typing import List, Literal, Optional
 from datetime import datetime
-from pydantic import BaseModel, constr
+from pydantic import BaseModel, constr, Extra
+
 
 class Mentor(BaseModel):
     profile_id: constr(max_length=255)
@@ -31,11 +32,14 @@ class MentorUpdate(BaseModel):
     city: Optional[constr(max_length=255)]
     current_company: Optional[constr(max_length=255)]
     current_position: Optional[constr(max_length=255)]
-    tech_stack: constr(max_length=255)
+    tech_stack: Optional[constr(max_length=255)]
     able_to_commit: Optional[bool]
     mentor_contribution: Optional[List[constr(max_length=255)]]
     how_heard_about_us: Optional[constr(max_length=255)]
     anything_else: Optional[constr(max_length=2500)]
+
+    class Config:
+        extra = Extra.forbid
 
 
 class Mentee(BaseModel):
@@ -69,9 +73,12 @@ class MenteeUpdate(BaseModel):
     underrepresented_group: Optional[bool]
     low_income: Optional[bool]
     list_convictions: Optional[List[constr(max_length=255)]]
-    tech_stack: constr(max_length=255)
+    tech_stack: Optional[constr(max_length=255)]
     looking_for: Optional[List[constr(max_length=255)]]
     anything_else: Optional[constr(max_length=2500)]
+
+    class Config:
+        extra = Extra.forbid
 
 
 class Meeting(BaseModel):


### PR DESCRIPTION
## Description

https://www.loom.com/share/4ef2d85d8e2e446da1878e863f6b7d63

Added Config subclass to MentorUpdate and MenteeUpdate schemas to forbid any extra fields (fields no present in schema).
refactor update endpoints for mentors and mentees. + Change 'tech_stack' fields in MentorUpdate and MenteeUpdate schemas to be Optional (All fields in Update schemas need to be Optional to work properly).

Fixes # 
- MentorUpdate and MenteeUpdate enpoints and schemas allow for extra fields to be added into mentors and mentees profile.
- Required field error (tech_stack field) when trying to update mentee or mentor profile.

## Type of change

- [x] Bug fix

## Checklist:

- [x] My code follows PEP8 style guide
- [x] I have removed unnecessary print statements from my code
- [x] I have made corresponding changes to the documentation if necessary
- [x] My changes generate no errors
- [x] No commented-out code
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
