### PR TITLE
Update mentee and mentor schema

### DIFF
--- a/app/schema.py
+++ b/app/schema.py
@@ -15,8 +15,10 @@ class Mentor(BaseModel):
     current_company: constr(max_length=255)
     current_position: constr(max_length=255)
     tech_stack: constr(max_length=255)
+    job_help: bool
+    industry_knowledge: bool
+    pair_programming: bool
     able_to_commit: bool
-    mentor_contribution: List[constr(max_length=255)]
     how_heard_about_us: constr(max_length=255)
     anything_else: constr(max_length=2500)
 
@@ -32,8 +34,10 @@ class MentorUpdate(BaseModel):
     current_company: Optional[constr(max_length=255)]
     current_position: Optional[constr(max_length=255)]
     tech_stack: Optional[constr(max_length=255)]
+    job_help: Optional[bool]
+    industry_knowledge: Optional[bool]
+    pair_programming: Optional[bool]
     able_to_commit: Optional[bool]
-    mentor_contribution: Optional[List[constr(max_length=255)]]
     how_heard_about_us: Optional[constr(max_length=255)]
     anything_else: Optional[constr(max_length=2500)]
 
@@ -52,9 +56,11 @@ class Mentee(BaseModel):
     formerly_incarcerated: bool
     underrepresented_group: bool
     low_income: bool
-    list_convictions: List[constr(max_length=255)]
+    list_convictions: constr(max_length=255)
     tech_stack: constr(max_length=255)
-    looking_for: List[constr(max_length=255)]
+    job_help: bool
+    industry_knowledge: bool
+    pair_programming: bool
     how_heard_about_us: constr(max_length=255)
     anything_else: Optional[constr(max_length=2500)]
 
@@ -70,9 +76,11 @@ class MenteeUpdate(BaseModel):
     formerly_incarcerated: Optional[bool]
     underrepresented_group: Optional[bool]
     low_income: Optional[bool]
-    list_convictions: Optional[List[constr(max_length=255)]]
+    list_convictions: Optional[constr(max_length=255)]
     tech_stack: Optional[constr(max_length=255)]
-    looking_for: Optional[List[constr(max_length=255)]]
+    job_help: Optional[bool]
+    industry_knowledge: Optional[bool]
+    pair_programming: Optional[bool]
     how_heard_about_us: Optional[constr(max_length=255)]
     anything_else: Optional[constr(max_length=2500)]
 


### PR DESCRIPTION
## Description

Worked with Kevin to pair program updates to the mentee and mentor schemas.  The old schemas for both mentee and mentor had a field titled "looking_for" that had a selection for types of help either the mentee was interested in receiving or the mentor was hoping to provide.  This one field was separated into 3 separate fields for each option: job_help, industry_knowledge, and pair_programming.  The "looking_for" schema field was deleted and these 3 fields were added for the following schemas: Mentee, MenteeUpdate, Mentor, MentorUpdate.

Loom Link: https://www.loom.com/share/59b868e8db324a1e881e1e253864cae1

## Type of change

- [x] Bug fix

## Checklist:

- [x] My code follows PEP8 style guide
- [x] I have removed unnecessary print statements from my code
- [x] I have made corresponding changes to the documentation if necessary
- [x] My changes generate no errors
- [x] No commented-out code
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
