### PR TITLE
Modified MatcherSortSearch to match updated schema

### DIFF
--- a/app/model.py
+++ b/app/model.py
@@ -29,9 +29,9 @@ class MatcherSortSearch:
 
         def sort_mentors(mentor: Dict) -> Tuple:
             return (
-                mentee["experience_level"] != mentor["experience_level"],
                 mentee["pair_programming"] != mentor["pair_programming"],
-                mentor["industry_knowledge"],
+                mentee["job_help"] != mentor["job_help"],
+                mentee["industry_knowledge"] != mentor["industry_knowledge"],
             )
 
         results = sorted(


### PR DESCRIPTION
## Description

This bug fix updates the MatcherSortSearch Class in model.py to ensure that the matcher sorting fields are compatible with updated mentee and mentor schemas.  Previously, the matcher sorted by mentee/mentor experience level and by mentor industry knowledge.  However, experience level is no longer being used to sort search based on a request from the stakeholder.  The new mentee and mentor schemas both have boolean fields now for pair_programming, job_help, and industry_knowledge for what they are looking for from the program.  The matcher will sort based off mentee and mentor matches on these field entries.

Loom Video: https://www.loom.com/share/36b2e816acab4c1b8e057bd30a90d603 

## Type of change

- [x] Bug fix

## Checklist:

- [x] My code follows PEP8 style guide
- [x] I have removed unnecessary print statements from my code
- [x] I have made corresponding changes to the documentation if necessary
- [x] My changes generate no errors
- [x] No commented-out code
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
