### PR TITLE
updates RandomMentee and RandomMentor once again

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -188,8 +188,7 @@ async def create_mentee(data: Mentee):
 
 @API.post("/update/mentor/{profile_id}")
 async def update_mentors(profile_id: str, update_data: MentorUpdate):
-    """Updates Mentor documents that statisfy the query with update_data.
-    Queries from Mentor Collection with filters given (query).
+    """Updates Mentor document.
     Validate changes in update_data using MentorUpdate class (Pydantic schema)
     and updates the corresponding fields, by overwriting or adding data.
     Args:
@@ -204,8 +203,7 @@ async def update_mentors(profile_id: str, update_data: MentorUpdate):
 
 @API.post("/update/mentee/{profile_id}")
 async def update_mentees(profile_id: str, update_data: MenteeUpdate):
-    """Updates Mentee documents that statisfy the query with update_data.
-    Queries from Mentee Collection with filters given (query).
+    """Updates Mentee document.
     Validate changes in update_data using MenteeUpdate class (Pydantic schema)
     and updates the corresponding fields, by overwriting or adding data.
     Args:

--- a/app/api.py
+++ b/app/api.py
@@ -186,36 +186,36 @@ async def create_mentee(data: Mentee):
     return {"result": API.db.create("Mentees", data.dict())}
 
 
-@API.post("/update/mentor")
-async def update_mentors(query: Dict, update_data: MentorUpdate):
+@API.post("/update/mentor/{profile_id}")
+async def update_mentors(profile_id: str, update_data: MentorUpdate):
     """Updates Mentor documents that statisfy the query with update_data.
     Queries from Mentor Collection with filters given (query).
     Validate changes in update_data using MentorUpdate class (Pydantic schema)
     and updates the corresponding fields, by overwriting or adding data.
     Args:
-        query (dict): Key value pairs to filter for
+        profile_id (str): User Id
         update_data (dict): Key value pairs to update
     Returns:
         Updated fields or schema discrepancy error as dictionary
     """
     data = update_data.dict(exclude_none=True)
-    return {"result": API.db.update("Mentors", query, data)}
+    return {"result": API.db.update("Mentors", {"profile_id": profile_id}, data)}
 
 
-@API.post("/update/mentee")
-async def update_mentees(query: Dict, update_data: MenteeUpdate):
+@API.post("/update/mentee/{profile_id}")
+async def update_mentees(profile_id: str, update_data: MenteeUpdate):
     """Updates Mentee documents that statisfy the query with update_data.
     Queries from Mentee Collection with filters given (query).
     Validate changes in update_data using MenteeUpdate class (Pydantic schema)
     and updates the corresponding fields, by overwriting or adding data.
     Args:
-        query (dict): Key value pairs to filter for
+        profile_id (str): User Id
         update_data (dict): Key value pairs to update
     Returns:
         Updated fields or schema discrepancy error as dictionary
     """
     data = update_data.dict(exclude_none=True)
-    return {"result": API.db.update("Mentees", query, data)}
+    return {"result": API.db.update("Mentees", {"profile_id": profile_id}, data)}
 
 
 @API.post("/{collection}/search")

--- a/app/api.py
+++ b/app/api.py
@@ -186,7 +186,7 @@ async def create_mentee(data: Mentee):
     return {"result": API.db.create("Mentees", data.dict())}
 
 
-@API.post("/update/mentors")
+@API.post("/update/mentor")
 async def update_mentors(query: Dict, update_data: MentorUpdate):
     """Updates Mentor documents that statisfy the query with update_data.
     Queries from Mentor Collection with filters given (query).
@@ -202,7 +202,7 @@ async def update_mentors(query: Dict, update_data: MentorUpdate):
     return {"result": API.db.update("Mentors", query, data)}
 
 
-@API.post("/update/mentees")
+@API.post("/update/mentee")
 async def update_mentees(query: Dict, update_data: MenteeUpdate):
     """Updates Mentee documents that statisfy the query with update_data.
     Queries from Mentee Collection with filters given (query).

--- a/data_generators/seeds.py
+++ b/data_generators/seeds.py
@@ -1,8 +1,7 @@
 from random import choice
 
 from app.data import MongoDB
-from data_generators.user_generators import Mentee, Mentor
-from data_generators.user_generators import MenteeFeedback, Meeting, Resource
+from data_generators.user_generators import *
 
 
 class SeedMongo:
@@ -15,7 +14,7 @@ class SeedMongo:
         else:
             self.db.make_field_unique("Mentees", "profile_id")
         self.db.create_index("Mentees")
-        mentees = (vars(Mentee()) for _ in range(count))
+        mentees = (vars(RandomMentee()) for _ in range(count))
         self.db.create_many("Mentees", mentees)
 
     def mentors(self, fresh_db: bool, count: int):
@@ -25,7 +24,7 @@ class SeedMongo:
         else:
             self.db.make_field_unique("Mentors", "profile_id")
         self.db.create_index("Mentors")
-        mentors = (vars(Mentor()) for _ in range(count))
+        mentors = (vars(RandomMentor()) for _ in range(count))
         self.db.create_many("Mentors", mentors)
 
     def feedback(self, fresh_db: bool, count: int):
@@ -35,7 +34,7 @@ class SeedMongo:
             self.db.delete("Feedback", {})
         else:
             self.db.make_field_unique("Feedback", "ticket_id")
-        feedback = (vars(MenteeFeedback(
+        feedback = (vars(RandomMenteeFeedback(
             choice(mentees)["profile_id"],
             choice(mentors)["profile_id"],
         )) for _ in range(count))
@@ -48,7 +47,7 @@ class SeedMongo:
             self.db.delete("Meetings", {})
         else:
             self.db.make_field_unique("Meetings", "meeting_id")
-        meetings = (vars(Meeting(
+        meetings = (vars(RandomMeeting(
             choice(mentees)["profile_id"],
             choice(mentors)["profile_id"],
         )) for _ in range(count))
@@ -59,7 +58,7 @@ class SeedMongo:
             self.db.delete("Resources", {})
         else:
             self.db.make_field_unique("Resources", "item_id")
-        resources = (vars(Resource()) for _ in range(count))
+        resources = (vars(RandomResource()) for _ in range(count))
         self.db.create_many("Resources", resources)
 
     def __call__(self, fresh: bool):

--- a/data_generators/user_generators.py
+++ b/data_generators/user_generators.py
@@ -35,14 +35,14 @@ class RandomMentor(Printable):
         self.other_info = "anything else may be written here"
 
 
-class Mentee(Printable):
+class RandomMentee(Printable):
     """Generates Mentee record"""
 
     def __init__(self):
         self.profile_id = generate_uuid(16)
         self.first_name = random_first_name()
         self.last_name = choice(last_names)
-        self.email = self.first_name + "." + self.last_name + "@gmail"
+        self.email = f"{self.first_name}.{self.last_name}@gmail.com"
         self.country = "U.S."
         self.state = choice(states)
         self.city = choice(cities)
@@ -57,7 +57,7 @@ class Mentee(Printable):
         self.validate_status = choice(["approved", "pending"])
 
 
-class Resource(Printable):
+class RandomResource(Printable):
     """Generates Resource record"""
 
     def __init__(self):
@@ -65,7 +65,7 @@ class Resource(Printable):
         self.item_id = generate_uuid(16)
 
 
-class MenteeFeedback(Printable):
+class RandomMenteeFeedback(Printable):
     """Generates Feedback record from mentee"""
     file_path = os.path.join("data_generators", "review.csv")
     feedback = pd.read_csv(file_path, index_col="Id")
@@ -77,7 +77,7 @@ class MenteeFeedback(Printable):
         self.feedback = choice(self.feedback["Review"])
 
 
-class Meeting(Printable):
+class RandomMeeting(Printable):
     """Generates Meeting record"""
 
     def __init__(self, mentee_id, mentor_id):


### PR DESCRIPTION
## Description
1. Many updates for reseeding the DS database
2. Added Random to all generators' names to clearly differentiate them from other classes with the same names
  - RandomMentee
  - RandomMentor
  - RandomResource
  - RandomMenteeFeedback
  - RandomMeeting
3. Added `.com` to the end of randomly generated emails
4. Validated the seeding algorithm - looking for any possible issues with the new schema
5. Reseeded MongoDB
6. Quick fix to make the endpoints for updating users singular (removes the 's'). We only allow updating one at a time.
7. Adds the requirement of providing a profile_id url query to update a user

## Type of change
- [x] Bug fix

## Checklist:

- [x] My code follows PEP8 style guide
- [x] I have removed unnecessary print statements from my code
- [x] I have made corresponding changes to the documentation if necessary
- [x] My changes generate no errors
- [x] No commented-out code
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
