### PR TITLE
BL-450 - (1/3) Schema from Postgres tables mirrored in `schema.py` - Team D

### DIFF
--- a/app/schema.py
+++ b/app/schema.py
@@ -96,6 +96,8 @@ class MenteeUpdate(BaseModel):
 
 
 class Meeting(BaseModel):
+    """host_id references profile_id in Profiles collection
+    attendee_id references profile_id in Profiles collection"""
     meeting_id: constr(max_length=255)
     created_at: datetime
     updated_at: datetime
@@ -105,7 +107,7 @@ class Meeting(BaseModel):
     host_id: constr(max_length=255)
     attendee_id: constr(max_length=255)
     meeting_notes: Optional[constr(max_length=2000)]
-    meeting_missed: Optional[Literal['Missed', 'Attended']]
+    meeting_missed: Optional[Literal['Missed', 'Pending', 'Attended']]
 
 
 class MeetingUpdate(BaseModel):
@@ -195,16 +197,6 @@ class MenteeIntake(BaseModel):
     validate_status: constr(max_length=255)
 
 
-class Meetings(BaseModel):
-    """host_id references profile_id in Profiles collection
-    attendee_id references profile_id in Profiles collection"""
-    meeting_id: constr(max_length=255)
-    created_at: datetime
-    updated_at: datetime
-    meeting_topic: constr(max_length=255)
-    meeting_start_date: datetime
-    meeting_end_date: datetime
-    host_id: constr(max_length=255)
-    attendee_id: constr(max_length=255)
-    meeting_notes: Optional[constr(max_length=2000)]
-    meeting_missed: Optional[Literal['Missed', 'Pending', 'Attended']]
+class Role(BaseModel):
+    role_id: constr(max_length=255)
+    role_name: constr(max_length=255)

--- a/app/schema.py
+++ b/app/schema.py
@@ -136,7 +136,7 @@ class Resource(BaseModel):
 
 class Profiles(BaseModel):
     profile_id: constr(max_length=255)
-    email: constr(max_length=255)
+    email: EmailStr
     first_name: constr(max_length=255)
     last_name: constr(max_length=255)
     location: constr(max_length=255)
@@ -153,7 +153,7 @@ class MentorIntake(BaseModel):
     profile_id: constr(max_length=255)
     first_name: constr(max_length=255)
     last_name: constr(max_length=255)
-    email: constr(max_length=255)
+    email: EmailStr
 
 
 class MenteeIntake(BaseModel):

--- a/app/schema.py
+++ b/app/schema.py
@@ -154,3 +154,11 @@ class MentorIntake(BaseModel):
     first_name: constr(max_length=255)
     last_name: constr(max_length=255)
     email: constr(max_length=255)
+
+
+class MenteeIntake(BaseModel):
+    intake_id: constr(max_length=255)
+    profile_id: constr(max_length=255)
+    first_name: constr(max_length=255)
+    last_name: constr(max_length=255)
+    email: EmailStr

--- a/app/schema.py
+++ b/app/schema.py
@@ -131,3 +131,26 @@ class Feedback(BaseModel):
 class Resource(BaseModel):
     name: constr(max_length=255)
     item_id: constr(max_length=255)
+
+# Mirror of PostgresSQL Database begins:
+
+class Profiles(BaseModel):
+    profile_id: constr(max_length=255)
+    email: constr(max_length=255)
+    first_name: constr(max_length=255)
+    last_name: constr(max_length=255)
+    location: constr(max_length=255)
+    company: constr(max_length=255)
+    tech_stack: constr(max_length=255)
+    created_at: datetime
+    is_active: bool
+    progress_status: constr(max_length=255)
+    attendance_rate: constr(max_length=255)
+
+
+class MentorIntake(BaseModel):
+    intake_id: constr(max_length=255)
+    profile_id: constr(max_length=255)
+    first_name: constr(max_length=255)
+    last_name: constr(max_length=255)
+    email: constr(max_length=255)

--- a/app/schema.py
+++ b/app/schema.py
@@ -61,7 +61,7 @@ class Mentee(BaseModel):
     underrepresented_group: bool
     low_income: bool
     list_convictions: List[constr(max_length=255)]
-    tech_stack: constr(max_length=255)
+    tech_stack: constr(max_length=255) # Mentor class takes list here instead
     job_help: bool
     pair_programming: bool
     heard_about: constr(max_length=255)
@@ -132,8 +132,8 @@ class Resource(BaseModel):
     name: constr(max_length=255)
     item_id: constr(max_length=255)
 
-# Mirror of PostgresSQL Database begins:
 
+# Mirror of PostgresSQL Database begins:
 class Profiles(BaseModel):
     profile_id: constr(max_length=255)
     email: EmailStr
@@ -142,6 +142,7 @@ class Profiles(BaseModel):
     location: constr(max_length=255)
     company: constr(max_length=255)
     tech_stack: constr(max_length=255)
+    role_id: constr(max_length=255)
     created_at: datetime
     is_active: bool
     progress_status: constr(max_length=255)
@@ -149,16 +150,30 @@ class Profiles(BaseModel):
 
 
 class MentorIntake(BaseModel):
-    intake_id: constr(max_length=255)
+    mentor_intake_id: constr(max_length=255)
+    email: EmailStr
     profile_id: constr(max_length=255)
     first_name: constr(max_length=255)
     last_name: constr(max_length=255)
-    email: EmailStr
+    country: constr(max_length=255)
+    state: constr(max_length=255)
+    city: constr(max_length=255)
+    current_company: constr(max_length=255)
+    current_position: constr(max_length=255)
+    tech_stack: constr(max_length=255)
+    job_help: constr(max_length=255)
+    industry_knowledge: constr(max_length=255)
+    pair_programming: constr(max_length=255)
+    commitment: constr(max_length=255)
+    referred_by: constr(max_length=255)
+    other_info: Optional[constr(max_length=2500)]
+    validate_status: constr(max_length=255)
 
 
 class MenteeIntake(BaseModel):
     intake_id: constr(max_length=255)
     profile_id: constr(max_length=255)
+    email: EmailStr
     first_name: constr(max_length=255)
     last_name: constr(max_length=255)
-    email: EmailStr
+

--- a/app/schema.py
+++ b/app/schema.py
@@ -61,7 +61,7 @@ class Mentee(BaseModel):
     underrepresented_group: bool
     low_income: bool
     list_convictions: List[constr(max_length=255)]
-    tech_stack: constr(max_length=255) # Mentor class takes list here instead
+    tech_stack: constr(max_length=255)
     job_help: bool
     pair_programming: bool
     heard_about: constr(max_length=255)
@@ -160,20 +160,32 @@ class MentorIntake(BaseModel):
     city: constr(max_length=255)
     current_company: constr(max_length=255)
     current_position: constr(max_length=255)
-    tech_stack: constr(max_length=255)
+    tech_stack: List[constr(max_length=255)]
     job_help: constr(max_length=255)
     industry_knowledge: constr(max_length=255)
     pair_programming: constr(max_length=255)
     commitment: constr(max_length=255)
-    referred_by: constr(max_length=255)
+    referred_by: Optional[constr(max_length=255)]
     other_info: Optional[constr(max_length=2500)]
     validate_status: constr(max_length=255)
 
 
 class MenteeIntake(BaseModel):
-    intake_id: constr(max_length=255)
+    mentee_intake_id: constr(max_length=255)
     profile_id: constr(max_length=255)
     email: EmailStr
+    country: constr(max_length=255)
+    city: constr(max_length=255)
+    state: constr(max_length=255)
     first_name: constr(max_length=255)
     last_name: constr(max_length=255)
-
+    tech_stack: constr(max_length=255)
+    formerly_incarcerated: bool
+    underrepresented_group: bool
+    low_income: bool
+    list_convictions: List[constr(max_length=255)]
+    job_help: bool
+    pair_programming: bool
+    heard_about: Optional[constr(max_length=255)]
+    other_info: Optional[constr(max_length=2500)]
+    validate_status: constr(max_length=255)

--- a/app/schema.py
+++ b/app/schema.py
@@ -193,3 +193,18 @@ class MenteeIntake(BaseModel):
     heard_about: Optional[constr(max_length=255)]
     other_info: Optional[constr(max_length=2500)]
     validate_status: constr(max_length=255)
+
+
+class Meetings(BaseModel):
+    """host_id references profile_id in Profiles collection
+    attendee_id references profile_id in Profiles collection"""
+    meeting_id: constr(max_length=255)
+    created_at: datetime
+    updated_at: datetime
+    meeting_topic: constr(max_length=255)
+    meeting_start_date: datetime
+    meeting_end_date: datetime
+    host_id: constr(max_length=255)
+    attendee_id: constr(max_length=255)
+    meeting_notes: Optional[constr(max_length=2000)]
+    meeting_missed: Optional[Literal['Missed', 'Pending', 'Attended']]

--- a/app/schema.py
+++ b/app/schema.py
@@ -133,7 +133,9 @@ class Resource(BaseModel):
     item_id: constr(max_length=255)
 
 
+# --------------------------------------
 # Mirror of PostgresSQL Database begins:
+
 class Profiles(BaseModel):
     profile_id: constr(max_length=255)
     email: EmailStr
@@ -150,6 +152,7 @@ class Profiles(BaseModel):
 
 
 class MentorIntake(BaseModel):
+    '''profile_id references profile_id from Profile schema'''
     mentor_intake_id: constr(max_length=255)
     email: EmailStr
     profile_id: constr(max_length=255)
@@ -171,6 +174,7 @@ class MentorIntake(BaseModel):
 
 
 class MenteeIntake(BaseModel):
+    '''profile_id references profile_id from Profile schema'''
     mentee_intake_id: constr(max_length=255)
     profile_id: constr(max_length=255)
     email: EmailStr

--- a/app/schema.py
+++ b/app/schema.py
@@ -96,8 +96,7 @@ class MenteeUpdate(BaseModel):
 
 
 class Meeting(BaseModel):
-    """host_id references profile_id in Profiles collection
-    attendee_id references profile_id in Profiles collection"""
+    """NOTE: 'Meetings' table from postgres nearly identical"""
     meeting_id: constr(max_length=255)
     created_at: datetime
     updated_at: datetime
@@ -107,7 +106,7 @@ class Meeting(BaseModel):
     host_id: constr(max_length=255)
     attendee_id: constr(max_length=255)
     meeting_notes: Optional[constr(max_length=2000)]
-    meeting_missed: Optional[Literal['Missed', 'Pending', 'Attended']]
+    meeting_missed: Optional[Literal['Missed', 'Attended']]
 
 
 class MeetingUpdate(BaseModel):
@@ -195,6 +194,21 @@ class MenteeIntake(BaseModel):
     heard_about: Optional[constr(max_length=255)]
     other_info: Optional[constr(max_length=2500)]
     validate_status: constr(max_length=255)
+
+
+class Meetings(BaseModel):
+    """host_id references profile_id in Profiles collection
+    attendee_id references profile_id in Profiles collection"""
+    meeting_id: constr(max_length=255)
+    created_at: datetime
+    updated_at: datetime
+    meeting_topic: constr(max_length=255)
+    meeting_start_date: datetime
+    meeting_end_date: datetime
+    host_id: constr(max_length=255)
+    attendee_id: constr(max_length=255)
+    meeting_notes: Optional[constr(max_length=2000)]
+    meeting_missed: Optional[Literal['Missed', 'Attended']]
 
 
 class Role(BaseModel):


### PR DESCRIPTION
## Description

Copied schema format from Postgres tables for use in schema.py. Due to [redundant data](https://docs.google.com/spreadsheets/d/1oN_fJCTZVBwMbRVW-fHmRadpX0RlCMt4a0J-M7qUN88/edit?usp=sharing) stored in MongoDB and Postgres, 
we've decided to migrate to MongoDB for the bulk of data storage and handling. This PR is a first step in that elaborate process.

Fixes # [BL-450](https://bloomtechlabs.atlassian.net/browse/BL-450?atlOrigin=eyJpIjoiZDJkMzUwYWU1ZDAyNGE2N2EwZGE5ZTNlNmQ0YWFiYjUiLCJwIjoiaiJ9)
Team D -- tables transferred: `Meetings`, `Profiles`, `MentorIntake`, `MenteeIntake`, `Roles`

## Type of change

- [x] New feature

## Checklist:

- [x] My code follows PEP8 style guide
- [x] I have removed unnecessary print statements from my code
- [x] My changes generate no errors
- [x] No commented-out code
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
https://www.loom.com/share/363b0f6374804a8192c09cb41c0e12f3