### PR TITLE
BL-450 - (3/3) Schema from Postgres tables mirrored in schema.py - Team B

### DIFF
--- a/app/schema.py
+++ b/app/schema.py
@@ -136,8 +136,8 @@ class Tickets_Table(BaseModel):
     ticket_id: constr(max_length=255)
     ticket_type: Optional[Literal['Action', 'Application', 'Resource', 'Role']]
     ticket_status: Optional[Literal['Pending', 'Approved', 'Rejected']]
-    ticket_subject: Optional[Literal['Action', 'Application', 'Resource', 'Role']]
-    urgent: Optional[Literal['Mild', 'A Little Mild', 'Urgent']]
+    ticket_subject: constr(max_length=255)
+    urgent: Optional[Literal['Low', 'Normal', 'High']]
     notes: constr(max_length=255)
     requested_for: constr(max_length=255)
     submitted_by: constr(max_length=255)

--- a/app/schema.py
+++ b/app/schema.py
@@ -132,6 +132,7 @@ class Resource(BaseModel):
     name: constr(max_length=255)
     item_id: constr(max_length=255)
 
+
 class Tickets_Table(BaseModel):
     ticket_id: constr(max_length=255)
     ticket_type: Optional[Literal['Action', 'Application', 'Resource', 'Role']]
@@ -143,8 +144,21 @@ class Tickets_Table(BaseModel):
     submitted_by: constr(max_length=255)
     approved_by: constr(max_length=255)
 
+
 class Assignment(BaseModel):
     mentor_id: constr(max_length=255)
     mentee_id: constr(max_length=255)
     assignment_id: constr(max_length=255)
 
+
+class Resources(BaseModel):
+    resource_id: constr(max_length=255)
+    updated_at: constr(max_length=255)
+    resource_name: constr(max_length=255)
+    category: constr(max_length=255)
+    condition: constr(max_length=255)
+    assigned: constr(max_length=255)
+    current_assignee: constr(max_length=255)
+    previous_assignee: constr(max_length=255)
+    monetary_value: constr(max_length=255)
+    deductible_donation: constr(max_length=255)

--- a/app/schema.py
+++ b/app/schema.py
@@ -131,3 +131,15 @@ class Feedback(BaseModel):
 class Resource(BaseModel):
     name: constr(max_length=255)
     item_id: constr(max_length=255)
+
+class Tickets_Table(BaseModel):
+    ticket_id: constr(max_length=255)
+    ticket_type: Optional[Literal['Action', 'Application', 'Resource', 'Role']]
+    ticket_status: Optional[Literal['Pending', 'Approved', 'Rejected']]
+    ticket_subject: Optional[Literal['Action', 'Application', 'Resource', 'Role']]
+    urgent: Optional[Literal['Mild', 'A Little Mild', 'Urgent']]
+    notes: constr(max_length=255)
+    requested_for: constr(max_length=255)
+    submitted_by: constr(max_length=255)
+    approved_by: constr(max_length=255)
+

--- a/app/schema.py
+++ b/app/schema.py
@@ -1,6 +1,6 @@
 from typing import Literal, Optional, List
 from datetime import datetime
-from pydantic import BaseModel, constr, Extra, EmailStr
+from pydantic import BaseModel, constr, Extra, EmailStr, conint
 
 
 class Mentor(BaseModel):
@@ -162,3 +162,11 @@ class Resources(BaseModel):
     previous_assignee: constr(max_length=255)
     monetary_value: constr(max_length=255)
     deductible_donation: constr(max_length=255)
+
+
+class Reviews(BaseModel):
+    review_id: constr(max_length=255)
+    review: constr(max_length=255)
+    rating: conint(ge=1, le=5)
+    mentee_id: constr(max_length=255)
+    mentor_id: constr(max_length=255)


### PR DESCRIPTION
## Description

In order to address the issues of redundant or non-existing schema tables, we have copied over schema collections from the Postgres tables into our MongoDB schema. This is a Data Science group effort to mirror the Postgres tables onto our side, providing access to more data and giving us additional tables to work with. 
By completing this mirroring process, Data Science students can work with additional information that will lead to creative ideas for improvement and analyzation of the project. This is the third and final pull request of the BL-450 issue. Team B has taken care of the following tables:
-Assignment
-Resources
-Reviews
-Tickets Table

[Loom Video](https://www.loom.com/share/f050fcbdd28649578e4ec89e01823670)

Fixes # [BL-450](https://bloomtechlabs.atlassian.net/jira/software/c/projects/BL/boards/10?modal=detail&selectedIssue=BL-450&search=bl-450)

_Co-authored by Anna Koduru, Logan Olbrich, and Steve Spradling._

## Type of change

Please delete options that are not relevant.

- [x] New feature

## Checklist:

- [x] My code follows PEP8 style guide
- [x] I have removed unnecessary print statements from my code
- [x] I have made corresponding changes to the documentation if necessary
- [x] My changes generate no errors
- [x] No commented-out code
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
