### PR TITLE
BL-588 Removed unnecessary fields from Meeting and MeetingUpdate schema

### DIFF
--- a/app/schema.py
+++ b/app/schema.py
@@ -114,7 +114,6 @@ class MenteeUpdate(BaseModel):
 class Meeting(BaseModel):
     meeting_id: constr(max_length=255)
     created_at: datetime
-    updated_at: datetime
     meeting_topic: constr(max_length=255)
     meeting_start_time: datetime
     meeting_end_time: datetime
@@ -130,8 +129,6 @@ class Meeting(BaseModel):
 
 
 class MeetingUpdate(BaseModel):
-    meeting_id: Optional[constr(max_length=255)]
-    created_at: Optional[datetime]
     updated_at: datetime
     meeting_topic: Optional[constr(max_length=255)]
     meeting_start_time: Optional[datetime]
@@ -145,7 +142,6 @@ class MeetingUpdate(BaseModel):
 
     class Config:
         extra = Extra.forbid
-
 
 
 class Resource(BaseModel):


### PR DESCRIPTION
## Description

Removed the `updated_at` field from Meeting because we do not need an update field before it has been updated.
Also removed `meeting_id` and `created_at` from MeetingUpdate because we do not want these to be updated.

Fixes # [BL-586](https://bloomtechlabs.atlassian.net/jira/software/c/projects/BL/boards/10?modal=detail&selectedIssue=BL-586)

## Type of change

- [x] New feature


## Checklist:

- [x] My code follows PEP8 style guide
- [x] I have removed unnecessary print statements from my code
- [x] I have made corresponding changes to the documentation if necessary
- [x] My changes generate no errors
- [x] No commented-out code
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes


[Loom video](https://www.loom.com/share/d012b2a9add54d24851b38cce2c9392f)
