### PR TITLE
BL-877 DS Implement timestamping for create_many database method

### DIFF
--- a/app/data.py
+++ b/app/data.py
@@ -1,8 +1,9 @@
 from datetime import datetime
 import json
 from os import getenv
-from typing import Optional, List, Dict, Iterator, Tuple
+from typing import Optional, List, Dict, Iterable, Tuple
 
+import certifi
 from pymongo import MongoClient
 from dotenv import load_dotenv
 
@@ -11,7 +12,7 @@ class MongoDB:
     load_dotenv()
 
     def database(self):
-        return MongoClient(getenv("MONGO_URL"))["UnderdogDevs"]
+        return MongoClient(getenv("MONGO_URL"), tlsCAFile=certifi.where())["UnderdogDevs"]
 
     def collection(self, collection):
         return self.database()[collection]
@@ -22,9 +23,9 @@ class MongoDB:
             collection,
         ).insert_one(self.timestamp(data)).acknowledged
 
-    def create_many(self, collection: str, data: Iterator[Dict]):
+    def create_many(self, collection: str, data: Iterable[Dict]):
         """ Insert multiple documents into a collection """
-        self.collection(collection).insert_many(self.timestamp(map(dict, data), "created_at"))
+        self.collection(collection).insert_many(map(self.timestamp, data))
 
     def first(self, collection: str, query: Optional[Dict] = None) -> Dict:
         """ Return first document in collection """

--- a/app/data.py
+++ b/app/data.py
@@ -24,7 +24,7 @@ class MongoDB:
 
     def create_many(self, collection: str, data: Iterator[Dict]):
         """ Insert multiple documents into a collection """
-        self.collection(collection).insert_many(map(dict, data))
+        self.collection(collection).insert_many(self.timestamp(map(dict, data), "created_at"))
 
     def first(self, collection: str, query: Optional[Dict] = None) -> Dict:
         """ Return first document in collection """

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,4 @@ pydantic[email]==1.9.1
 vaderSentiment==3.3.2
 uvicorn[standard]==0.17.6
 gunicorn==20.1.0
-
 certifi~=2022.6.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ pydantic[email]==1.9.1
 vaderSentiment==3.3.2
 uvicorn[standard]==0.17.6
 gunicorn==20.1.0
+
+certifi~=2022.6.15


### PR DESCRIPTION
## Description
By adding the timestamp to the create_many method we're are removing the theoretical wall that was standing in the way between it and our randomizer's ability to do its job. This sequence of events was causing some turbulence for Front-End if they ever decided to do something CRAZY like request more than a single document in one call. Next, I was having difficulty making an errorless connection to our database and realized that MongoClient requires TLS certificate for secure communication sometimes python is unable to request via TLS so we explicitly mention for MongoClient to request to MongoDB using certifi package. Certifi has been added to requirements.txt. If anyone has any questions or concerns, feel free to reach out and I'll do my best to field them. Happy Coding!!!

## Jira Ticket
[The Sandman the KanBan and Me](https://bloomtechlabs.atlassian.net/browse/BL-877)

## Type of Change
- [x] Bug fix

## Checklist
- [x] My code follows PEP8 style guide
- [x] I have removed unnecessary print statements from my code
- [x] I have made corresponding changes to the documentation if necessary
- [x] My changes generate no errors
- [x] No commented-out code
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes


## Loom Video
https://www.loom.com/share/1da01f72153f41779d5a5453c0dbc5c1
