### PR TITLE
BL-994-ds-implement-database-changes-for-meetings

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -47,7 +47,11 @@ async def collections():
     return {"result": API.db.get_database_info()}
 
 
-for router in (mentor_router, mentee_router, feedback_router,
-               graph_router, model_router, match_router,
+for router in (mentor_router,
+               mentee_router,
+               feedback_router,
+               graph_router,
+               model_router,
+               match_router,
                meeting_router):
     API.include_router(router.Router)

--- a/app/api.py
+++ b/app/api.py
@@ -9,7 +9,8 @@ from app.routers import (mentor_router,
                          feedback_router,
                          graph_router,
                          model_router,
-                         match_router)
+                         match_router,
+                         meeting_router)
 
 API = FastAPI(
     title='Underdog Devs DS API',
@@ -46,5 +47,7 @@ async def collections():
     return {"result": API.db.get_database_info()}
 
 
-for router in (mentor_router, mentee_router, feedback_router, graph_router, model_router, match_router):
+for router in (mentor_router, mentee_router, feedback_router,
+               graph_router, model_router, match_router,
+               meeting_router):
     API.include_router(router.Router)

--- a/app/api.py
+++ b/app/api.py
@@ -14,7 +14,7 @@ from app.routers import (mentor_router,
 
 API = FastAPI(
     title='Underdog Devs DS API',
-    version="0.51.3",
+    version="0.51.4",
     docs_url='/',
 )
 

--- a/app/routers/meeting_router.py
+++ b/app/routers/meeting_router.py
@@ -38,7 +38,7 @@ async def read_meeting(data: Optional[Dict] = None):
     return {"result": Router.db.read("Meetings", data)}
 
 
-@Router.put("/update/meeting/{meeting_id}")
+@Router.patch("/update/meeting/{meeting_id}")
 async def update_meeting(meeting_id: str, update_data: MeetingUpdate):
     """Updates a meeting
     <pre><code>
@@ -51,7 +51,7 @@ async def update_meeting(meeting_id: str, update_data: MeetingUpdate):
         "Meetings", {"meeting_id": meeting_id}, data)}
 
 
-@Router.delete("/delete/meeting")
+@Router.delete("/delete/meeting/{meeting_id}")
 async def delete_meeting(meeting_id: str):
     """Deletes meeting
     <pre><code>

--- a/app/routers/meeting_router.py
+++ b/app/routers/meeting_router.py
@@ -18,7 +18,8 @@ async def create_meeting(data: Meeting):
     """Creates a meeting
     <pre><code>
     @param data: JSON[Meeting]
-    @return JSON[Boolean] - Indicates success or failure of document creation</pre></code>"""
+    @return JSON[Boolean] - Indicates success or failure of document creation
+    </pre></code>"""
     try:
         return {"result": Router.db.create("Meetings", data.dict())}
     except DuplicateKeyError:
@@ -32,7 +33,8 @@ async def read_meeting(data: Optional[Dict] = None):
     Displays all meetings if no input provided
     <pre><code>
     @param data: JSON[Optional[Dict]]
-    @return JSON[Array[Meeting]]</pre></code>"""
+    @return JSON[Array[Meeting]]
+    </pre></code>"""
     return {"result": Router.db.read("Meetings", data)}
 
 
@@ -42,7 +44,8 @@ async def update_meeting(meeting_id: str, update_data: MeetingUpdate):
     <pre><code>
     @param meeting_id: str
     @param update_data: JSON[MeetingUpdate]
-    @return JSON[Boolean] - Indicates success or failure of update</pre></code>"""
+    @return JSON[Boolean] - Indicates success or failure of update
+    </pre></code>"""
     data = update_data.dict(exclude_none=True, exclude_unset=True)
     return {"result": Router.db.update(
         "Meetings", {"meeting_id": meeting_id}, data)}
@@ -53,6 +56,7 @@ async def delete_meeting(meeting_id: str):
     """Deletes meeting
     <pre><code>
     @param meeting_id: str
-    @return JSON[JSON[meeting_id]]</pre></code>"""
+    @return JSON[JSON[meeting_id]]
+    </pre></code>"""
     Router.db.delete("Meetings", {"meeting_id": meeting_id})
     return {"result": {"deleted": meeting_id}}

--- a/app/routers/meeting_router.py
+++ b/app/routers/meeting_router.py
@@ -26,9 +26,10 @@ async def create_meeting(data: Meeting):
             status_code=409, detail="Meeting ID must be unique.")
 
 
-@Router.get("/read/meeting/{profile_id}")
+@Router.post("/read/meeting")
 async def read_meeting(data: Optional[Dict] = None):
-    """Displays meeting(s) that meet provided criteria. Displays all meetings if no input provided
+    """Displays meeting(s) that meet provided criteria.
+    Displays all meetings if no input provided
     <pre><code>
     @param data: JSON[Optional[Dict]]
     @return JSON[Array[Meeting]]</pre></code>"""
@@ -42,8 +43,9 @@ async def update_meeting(meeting_id: str, update_data: MeetingUpdate):
     @param meeting_id: str
     @param update_data: JSON[MeetingUpdate]
     @return JSON[Boolean] - Indicates success or failure of update</pre></code>"""
-    data = update_data.dict(exclude_none=True)
-    return {"result": Router.db.update("Meeting", {"meeting_id": meeting_id}, data)}
+    data = update_data.dict(exclude_none=True, exclude_unset=True)
+    return {"result": Router.db.update(
+        "Meetings", {"meeting_id": meeting_id}, data)}
 
 
 @Router.delete("/delete/meeting")
@@ -52,5 +54,5 @@ async def delete_meeting(meeting_id: str):
     <pre><code>
     @param meeting_id: str
     @return JSON[JSON[meeting_id]]</pre></code>"""
-    Router.db.delete("Meeting", {"meeting_id": meeting_id})
+    Router.db.delete("Meetings", {"meeting_id": meeting_id})
     return {"result": {"deleted": meeting_id}}

--- a/app/routers/meeting_router.py
+++ b/app/routers/meeting_router.py
@@ -1,0 +1,56 @@
+from typing import Optional, Dict
+
+from fastapi import APIRouter, HTTPException
+from pymongo.errors import DuplicateKeyError
+
+from app.data import MongoDB
+from app.schema import Meeting, MeetingUpdate
+
+Router = APIRouter(
+    tags=["Meeting Operations"],
+)
+
+Router.db = MongoDB()
+
+
+@Router.post("/create/meeting")
+async def create_meeting(data: Meeting):
+    """Creates a meeting
+    <pre><code>
+    @param data: JSON[Meeting]
+    @return JSON[Boolean] - Indicates success or failure of document creation</pre></code>"""
+    try:
+        return {"result": Router.db.create("Meetings", data.dict())}
+    except DuplicateKeyError:
+        raise HTTPException(
+            status_code=409, detail="Meeting ID must be unique.")
+
+
+@Router.get("/read/meeting/{profile_id}")
+async def read_meeting(data: Optional[Dict] = None):
+    """Displays meeting(s) that meet provided criteria. Displays all meetings if no input provided
+    <pre><code>
+    @param data: JSON[Optional[Dict]]
+    @return JSON[Array[Meeting]]</pre></code>"""
+    return {"result": Router.db.read("Meetings", data)}
+
+
+@Router.put("/update/meeting/{meeting_id}")
+async def update_meeting(meeting_id: str, update_data: MeetingUpdate):
+    """Updates a meeting
+    <pre><code>
+    @param meeting_id: str
+    @param update_data: JSON[MeetingUpdate]
+    @return JSON[Boolean] - Indicates success or failure of update</pre></code>"""
+    data = update_data.dict(exclude_none=True)
+    return {"result": Router.db.update("Meeting", {"meeting_id": meeting_id}, data)}
+
+
+@Router.delete("/delete/meeting")
+async def delete_meeting(meeting_id: str):
+    """Deletes meeting
+    <pre><code>
+    @param meeting_id: str
+    @return JSON[JSON[meeting_id]]</pre></code>"""
+    Router.db.delete("Meeting", {"meeting_id": meeting_id})
+    return {"result": {"deleted": meeting_id}}

--- a/app/schema.py
+++ b/app/schema.py
@@ -111,8 +111,8 @@ class MeetingUpdate(ExtraForbid):
     meeting_topic: Optional[constr(max_length=255)]
     meeting_start_time: Optional[datetime]
     meeting_end_time: Optional[datetime]
-    mentor_id: constr(max_length=36)
-    mentee_id: constr(max_length=36)
+    mentor_id: Optional[constr(max_length=36)]
+    mentee_id: Optional[constr(max_length=36)]
     admin_meeting_notes: Optional[constr(max_length=2000)]
     meeting_missed_by_mentee: Optional[Literal['Missed', 'Attended']]
     mentor_meeting_notes: Optional[constr(max_length=2000)]

--- a/tests/proper_integration_tests.ipynb
+++ b/tests/proper_integration_tests.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 107,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false
    },
@@ -21,18 +21,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 108,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
     "import requests\n",
-    "from data_generators.generators import RandomMentor, RandomMentee, RandomMenteeFeedback\n",
+    "from data_generators.generators import RandomMentor, RandomMentee, RandomMenteeFeedback, RandomMeeting\n",
     "from app.data import MongoDB"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 109,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,7 +52,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# URL for the request\n",
@@ -61,10 +64,7 @@
     "url_create_mentor = f'{url}/create/mentor'\n",
     "url_read_mentor = f'{url}/read/mentor'\n",
     "url_update_mentor = f'{url}/update/mentor/'\n"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -84,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 111,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +103,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 112,
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# Create a ONE test mentor with API, we should receive 'result': True\n",
@@ -113,10 +116,7 @@
     "\n",
     "assert ret.status_code == expected_status, f\"Return status code was not {expected_status}. Got status code {ret.status_code}\"\n",
     "assert expected == ret.json(), \"Endpoint did not return expected value of {\\\"result\\\": True}\"\n"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -135,7 +135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 113,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -159,7 +159,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 115,
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# read from API, with no parameteres, we should get all the data\n",
@@ -168,10 +171,7 @@
     "\n",
     "assert ret.status_code == expected_status, f\"Return status code was not {expected_status}. Got status code {ret.status_code}\"\n",
     "assert len(ret.json()['result']) > 1, f\"We receive less that 2 entries. {len(ret.json()['result'])}\"\n"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -190,7 +190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 116,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -221,17 +221,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 117,
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# Mentees\n",
     "url_create_mentee = f'{url}/create/mentee'\n",
     "url_read_mentee = f'{url}/read/mentee'\n",
     "url_update_mentee = f'{url}/update/mentee/'\n"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -250,7 +250,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 118,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -270,7 +270,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 119,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -300,7 +300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 120,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -323,7 +323,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 121,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -353,7 +353,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 122,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -383,7 +383,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 123,
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# Feedback\n",
@@ -391,10 +394,7 @@
     "url_read_feedback = f'{url}/read/feedback'\n",
     "url_update_feedback = f'{url}/update/feedback?ticket_id='\n",
     "url_delete_feedback = f'{url}/delete/feedback?ticket_id='"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -405,7 +405,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 124,
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# Create a random feedback\n",
@@ -413,10 +416,7 @@
     "feedback['text'] = \"test_INTEGRATION_test\"\n",
     "\n",
     "assert feedback['ticket_id'] != '', f\"Something wrong with RandomMenteeFeedback() generator\"\n"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -428,7 +428,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 125,
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# Create ONE feedback\n",
@@ -439,10 +442,7 @@
     "\n",
     "assert ret.status_code == expected_status, f\"Return status code was not {expected_status}. Got status code {ret.status_code}\"\n",
     "assert ret.json() == expected, f\"Endpoint did not return expected value of {expected}\""
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -454,7 +454,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 126,
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# Create ONE feedback\n",
@@ -465,10 +468,7 @@
     "\n",
     "assert ret.status_code == expected_status, f\"Return status code was not {expected_status}. Got status code {ret.status_code}\"\n",
     "assert ret.json()['result'][0]['text'] == expected, f\"Endpoint did not return expected value of {expected}\""
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -480,37 +480,37 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "# There is some bug in *Update* endpoint\n",
     "- url is different from mentors/mentee\n",
     "- When i try to update , API return 500 error and   feedback.update({\"sentiment\": sentiment_rank(feedback[\"text\"])})\n"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 127,
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# expected_status = 200\n",
     "# expected = test_tag\n",
-    "#\n",
+    "\n",
     "# # update the test feedback\n",
     "# ret = requests.patch(url_update_feedback + feedback['ticket_id'], json={'mentee_id': test_tag})\n",
-    "#\n",
+    "\n",
     "# assert ret.status_code == expected_status, f\"Return status code was not {expected_status}. Got status code {ret.status_code}\"\n",
-    "#\n",
+    "\n",
     "# # read the test feedback, to check that we've successfully updated the entree\n",
     "# ret = requests.post(url_read_feedback, json=feedback['ticket_id'])\n",
-    "#\n",
+    "\n",
     "# assert ret.status_code == expected_status, f\"Return status code was not {expected_status}. Got status code {ret.status_code}\"\n",
     "# assert ret.json()['result'][0]['mentee_id'] == expected, f\"Endpoint did not return expected value of {expected}\"\n"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -522,7 +522,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 128,
+   "execution_count": 24,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "expected_status = 200\n",
@@ -530,52 +533,206 @@
     "ret = requests.delete(url_delete_feedback + feedback['ticket_id'])\n",
     "\n",
     "assert ret.status_code == expected_status, f\"Return status code was not {expected_status}. Got status code {ret.status_code}\""
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
-    "# Cleaning the test data\n",
-    "Cleaning the db, using db api by querying data marked with our test_tag\n"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+    "## Meeting Operations\n"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 129,
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url_create_meeting = f'{url}/create/meeting'\n",
+    "url_read_meeting = f'{url}/read/meeting'\n",
+    "url_update_meeting = f'{url}/update/meeting'\n",
+    "url_delete_meeting = f'{url}/delete/meeting?meeting_id='"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create meeting\n",
+    "CREATE `/create/meeting`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a random meeting\n",
+    "meeting = (vars(RandomMeeting(mentee_id='1', mentor_id='1')))\n",
+    "meeting['meeting_start_time'] = meeting['meeting_start_time'].isoformat()\n",
+    "meeting['meeting_end_time'] = meeting['meeting_end_time'].isoformat()\n",
+    "# Use topic field to identify our test records later\n",
+    "meeting['meeting_topic'] = test_tag"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expected = {\"result\": True}\n",
+    "expected_status = 200\n",
+    "\n",
+    "ret = requests.post(url_create_meeting, json=meeting)\n",
+    "\n",
+    "assert ret.status_code == expected_status, f\"Return status code was not {expected_status}. Got status code {ret.status_code}\"\n",
+    "assert expected == ret.json(), \"Endpoint did not return expected value of {\\\"result\\\": True}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Read one meeting by meeting_id\n",
+    "READ `/read/meeting`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expected_status = 200\n",
+    "expected = test_tag\n",
+    "\n",
+    "ret = requests.post(url_read_meeting, json={'meeting_id': meeting['meeting_id']})\n",
+    "\n",
+    "assert ret.status_code == expected_status, f\"Return status code was not {expected_status}. Got status code {ret.status_code}\"\n",
+    "assert ret.json()['result'][0]['meeting_topic'] == expected, f\"Endpoint did not return expected value of {expected}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Read all meetings\n",
+    "READ `/read/meeting`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expected_status = 200\n",
+    "\n",
+    "ret = requests.post(url_read_meeting)\n",
+    "\n",
+    "assert ret.status_code == expected_status, f\"Return status code was not {expected_status}. Got status code {ret.status_code}\"\n",
+    "assert len(ret.json()['result']) > 1, f\"We receive less that 2 entries. {len(ret.json()['result'])}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Update meeting\n",
+    "PUT `/update/meeting`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expected_status = 200\n",
+    "\n",
+    "ret = requests.put(f\"{url_update_meeting}/{meeting['meeting_id']}\", json={'mentor_meeting_notes': 'test_Bloomtech_test'})\n",
+    "\n",
+    "assert ret.status_code == expected_status, f\"Return status code was not {expected_status}. Got status code {ret.status_code}\"\n",
+    "\n",
+    "expected_status = 200\n",
+    "expected = 'test_Bloomtech_test'\n",
+    "\n",
+    "# Read the query with our test value\n",
+    "ret = requests.post(url_read_meeting, json={'mentor_meeting_notes': 'test_Bloomtech_test'})\n",
+    "\n",
+    "assert ret.status_code == expected_status, f\"Return status code was not {expected_status}. Got status code {ret.status_code}\"\n",
+    "assert expected == ret.json()['result'][0]['mentor_meeting_notes'], f\"Endpoint did not return expected value of {expected}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Delete meeting\n",
+    "DELETE `/delete/meeting`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expected_status = 200\n",
+    "\n",
+    "ret = requests.delete(url_delete_meeting + meeting['meeting_id'])\n",
+    "\n",
+    "assert ret.status_code == expected_status, f\"Return status code was not {expected_status}. Got status code {ret.status_code}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "# Cleaning the test data\n",
+    "Cleaning the db, using db api by querying data marked with our test_tag\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# Make a connection to the db\n",
     "db = MongoDB()\n",
     "\n",
     "# Mentors and Mentees clean up\n",
-    "for collection in ['Mentors', 'Mentees']:\n",
+    "for collection in ['Mentors', 'Mentees', 'Meetings']:\n",
     "    db.delete(collection, {'other_info': test_tag})\n",
+    "\n",
+    "db.delete('Meetings', {'meeting_topic': test_tag})\n",
     "\n",
     "# Feedback clean up\n",
     "db.delete('Feedback', {'text': test_tag})"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "### Check that we have successfully cleaned up the db.\n"
-   ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "source": [
+    "### Check that we have successfully cleaned up the db.\n"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 130,
+   "execution_count": 36,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# Mentors and Mentees\n",
@@ -583,27 +740,27 @@
     "    ret = db.search(collection, test_tag)\n",
     "    assert  ret == [], f\"Clean up of {collection} failed, found db record: {ret}\"\n",
     "\n",
+    "ret = db.read('Meetings', {'meeting_topic': test_tag})\n",
+    "assert  ret == [], f\"Clean up of Feedback failed, found db record: {ret}\"\n",
+    "\n",
     "# Feedback\n",
     "ret = db.read('Feedback', {'ticket_id': feedback['ticket_id']})\n",
     "assert  ret == [], f\"Clean up of Feedback failed, found db record: {ret}\"\n"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 130,
-   "outputs": [],
-   "source": [],
+   "execution_count": null,
    "metadata": {
     "collapsed": false
-   }
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.12 ('venv': venv)",
+   "display_name": "Python 3.8.0 ('venv': venv)",
    "language": "python",
    "name": "python3"
   },
@@ -617,12 +774,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.8.0"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "5c1e4bd171fb486a69b6e93433227d58b1f56d5ada82073d78c4386523828036"
+    "hash": "bd3cd9cc25d0861163890f405729cb6f2a1e87a0c4e46230918bac60dee04c9a"
    }
   }
  },


### PR DESCRIPTION
## Description
Per discussion with @JamesFincher, endpoints have been created for the following:
* POST for create meeting  
* ~PUT~ PATCH for update meeting  
* DELETE for delete meeting
* method for returning all meetings (using empty query, as with read/mentee and read/mentor)
* method for returning meetings for specified mentor or mentee profile id, or other identifying information (i.e., meeting id, as with read/mentee and read/mentor)
  
The following changes were made to schema:
- mentor_id and mentee_id become optional in meeting update, as meeting_id is the defining key.
  
Other considerations:
- Endpoints in meeting_router.py follow existing format from mentee/mentor router endpoints.
- Tests are included in `tests/proper_integration_tests.ipynb` following existing test format.
- Version is bumped by 0.0.1


## Jira Ticket
[Jira ticket](https://bloomtechlabs.atlassian.net/jira/software/c/projects/BL/boards/10?modal=detail&selectedIssue=BL-994)
## Type of Change
- [X] New feature

## Checklist
- [x] My code follows PEP8 style guide
- [x] I have removed unnecessary print statements from my code
- [x] I have made corresponding changes to the documentation if necessary
- [x] My changes generate no errors
- [x] No commented-out code
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes


## Loom Video
[Loom video](https://www.loom.com/share/aad206c3d5944071b153b89cfe32b499)