### PR TITLE
UD-285 DS-Matching for Mentors

### DIFF
--- a/app/routers/match_router.py
+++ b/app/routers/match_router.py
@@ -49,17 +49,18 @@ async def get_match(data: MatchQuery):
     """
     if data.user_type == "mentor":
         collection = "Mentees"
-        user_query = {"profile_id": {"$in": Router.db.first(
-            "Matches", {"mentor_id": data.user_id})['mentee_ids']}}
+        user_query = {"profile_id": {"$in": [match["mentee_id"] for match in Router.db.read(
+            "Matches", {"mentor_id": data.user_id})]}}
     elif data.user_type == "mentee":
         collection = "Mentors"
         user_query = {
             "profile_id": {
                 "$in": [mentor["mentor_id"] for mentor in Router.db.read(
-                    "Matches", {"mentee_ids": data.user_id})]
+                    "Matches", {"mentee_id": data.user_id})]
             }
         }
     else:
         raise ValueError("get_match: user_type must be 'mentor' or 'mentee'")
 
     return {"result": Router.db.read(collection, user_query)}
+


### PR DESCRIPTION
Currently the matching algorithm works for taking a mentee ID and matching them with mentors. Create the ability to do the same from the opposite where a mentor ID is called and a list of mentees is produced.

## Description
I had to figure out what the problem was, where the problem was and then if the changes were going to be simple or complex. The issue was dual functionality both nested in one function, where one request was working and the other wasn’t. After some research and discovery, I noticed that one metric could be changed and another field could be edited. The db.first method is used to retrieve one document so I changed it to the db.read method like in the else if statement below the if statement. I also changed the field of [mentee_ids] to [mentee_id] as the S is an added unnecessary character. 

## Jira Ticket
https://bloomtechlabs.atlassian.net/browse/UD-285?atlOrigin=eyJpIjoiMmRlODJlMWVjMWQzNDdiYTgyNDlkMGM4MzM0NDFjM2MiLCJwIjoiaiJ9

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] This change requires a documentation update

## Checklist
- [x] My code follows PEP8 style guide
- [x] I have removed unnecessary print statements from my code
- [x] I have made corresponding changes to the documentation if necessary
- [x] My changes generate no errors
- [x] No commented-out code
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes


## Loom Video
(https://www.loom.com/share/a6c1dae7be3f4036b121a1ab4bc22e2b)